### PR TITLE
seccomp: treat unlink and rmdir operations as no-follow

### DIFF
--- a/src/platform/linux/seccomp.rs
+++ b/src/platform/linux/seccomp.rs
@@ -1462,16 +1462,19 @@ struct Syscall {
 
 impl Syscall {
     /// Whether this invocation targets the symlink itself rather than what it
-    /// resolves to: an inherently no-follow call (`lchown`, `lsetxattr`,
-    /// `lremovexattr`) or an `*at` call carrying `AT_SYMLINK_NOFOLLOW`. The policy
-    /// check and the broker must then act on the link, not its target.
+    /// resolves to: an inherently no-follow call (`unlink`, `unlinkat`,
+    /// `rmdir`, `lchown`, `lsetxattr`, `lremovexattr`) or an `*at` call
+    /// carrying `AT_SYMLINK_NOFOLLOW`. The policy check and the broker must
+    /// then act on the link, not its target.
     fn no_follow(&self, args: &[u64; 6]) -> bool {
         // The flags argument is an int; truncating to i32 recovers it from the
         // u64 register slot the same way the dirfd arguments are read.
         let flag = |index: usize| syscall_i32(args[index]) & libc::AT_SYMLINK_NOFOLLOW != 0;
         let follow = |index: usize| syscall_i32(args[index]) & libc::AT_SYMLINK_FOLLOW != 0;
         match self.name {
-            "lchown" | "lsetxattr" | "lremovexattr" | "link" => true,
+            "unlink" | "unlinkat" | "rmdir" | "lchown" | "lsetxattr" | "lremovexattr" | "link" => {
+                true
+            }
             "fchownat" => flag(4),
             "fchmodat" | "fchmodat2" | "utimensat" => flag(3),
             // linkat(2) links the symlink itself unless AT_SYMLINK_FOLLOW is set;

--- a/tests/data.txt
+++ b/tests/data.txt
@@ -130,6 +130,7 @@ name=denyWrite permits unrelated write under symlink root | os=linux | setup=mkd
 # --- no-follow metadata syscalls act on the link ---
 
 name=no-follow chown permits in-tree link to out-of-root target | os=linux | setup=write:denied/secret:;symlink:%TMP%/denied/secret:allowed/link | policy={"network":{"allowNetwork":true},"filesystem":{"allowWrite":["%TMP%/allowed"],"denyRead":["/"],"allowRead":["/"]}} | cmd=%SHELL% -c 'chown -h "$(id -u):$(id -g)" "$1"' _ %TMP%/allowed/link | status=0
+name=unlink removes in-tree link to out-of-root target | os=linux | setup=write:denied/secret:;symlink:%TMP%/denied/secret:allowed/link | policy={"network":{"allowNetwork":true},"filesystem":{"allowWrite":["%TMP%/allowed"],"denyRead":["/"],"allowRead":["/"]}} | cmd=%SHELL% -c 'rm "$1"; test ! -L "$1"' _ %TMP%/allowed/link | status=0
 name=follow chown still gated on in-tree link to out-of-root target | os=linux | setup=write:denied/secret:;symlink:%TMP%/denied/secret:allowed/link | policy={"network":{"allowNetwork":true},"filesystem":{"allowWrite":["%TMP%/allowed"],"denyRead":["/"],"allowRead":["/"]}} | cmd=%SHELL% -c 'chown "$(id -u):$(id -g)" "$1"' _ %TMP%/allowed/link | status=!0 | out="code":"FILESYSTEM_DENIED" | out="reason":"allow_miss" | out="syscall":"fchownat"
 
 # --- glob write roots ---


### PR DESCRIPTION
In the Linux `seccomp` broker, `unlink`, `unlinkat`, and `rmdir` currently resolves a terminal symlink and reissues the operation against its target. This is in contrast to the no-follow semantics of the syscalls. For example, `rmdir`-ing a symlink to a directory should return `ENOTDIR` instead of removing the target.

One of the downstream bug is that `landstrip` can corrupt `uv`-managed Python installations during cleanup or reinstallation: removing an interpreter symlink may delete its target and leave a dangling link, after which `uv python list` no longer detects the installation.

This PR adds these three syscalls to the no-follow list so that `unlink` and `unlinkat` remove only the symlink, while `rmdir` returns `ENOTDIR` and preserves both the symlink and target directory. It also add a test for symlink removal.

Thank you for maintaining this awesome project and let me know if something is missing!