### PR TITLE
Show proxy errors to the client

### DIFF
--- a/packages/landstrip-api/lib/proxy.js
+++ b/packages/landstrip-api/lib/proxy.js
@@ -56,8 +56,10 @@ function splitHostPort(target, defaultPort) {
   return { host: target, port: defaultPort };
 }
 
-function denyProxyRequest(client, status = '403 Forbidden') {
-  client.write(`HTTP/1.1 ${status}\r\nContent-Length: 0\r\n\r\n`);
+function denyProxyRequest(client, status = '403 Forbidden', body) {
+  const bodyStr = body ? String(body) : '';
+  const bodyBuf = Buffer.from(bodyStr);
+  client.write(`HTTP/1.1 ${status}\r\nContent-Length: ${bodyBuf.length}\r\n\r\n${bodyBuf}`);
   client.end();
 }
 
@@ -139,10 +141,10 @@ function startFilterProxy(options) {
       },
     );
     trackUpstream(upstream, client, () => settled);
-    upstream.once('error', () => {
+    upstream.once('error', (err) => {
       if (settled) return;
       settled = true;
-      denyProxyRequest(client, '502 Bad Gateway');
+      denyProxyRequest(client, '502 Bad Gateway', err?.message || 'Bad Gateway');
     });
   }
 
@@ -211,10 +213,10 @@ function startFilterProxy(options) {
       pipeSockets(client, upstream, rest);
     });
     trackUpstream(upstream, client, () => settled);
-    upstream.once('error', () => {
+    upstream.once('error', (err) => {
       if (settled) return;
       settled = true;
-      denyProxyRequest(client, '502 Bad Gateway');
+      denyProxyRequest(client, '502 Bad Gateway', err?.message || 'Bad Gateway');
     });
   }
 
@@ -259,7 +261,7 @@ function startFilterProxy(options) {
         method?.toUpperCase() === 'CONNECT' && target
           ? handleConnect(client, target, rest)
           : handleHttp(client, header, rest);
-      task.catch(() => denyProxyRequest(client, '502 Bad Gateway'));
+      task.catch((err) => denyProxyRequest(client, '502 Bad Gateway', err?.message || 'Bad Gateway'));
     });
   }
 


### PR DESCRIPTION
The proxy server has multiple unobvious failure modes, which would be much easier to debug if they were displayed to the client.

For example, for pi, before:

```
 Agent — Test ping hello
   @general
 502 status code (no body)
```

And after (these are two different issues which I was banging my head on):

```
 Agent — Say hello
   @general
 502 Proxy destination is not public: fde3:bea9:729d::1
```

```
 Agent — Say hello
   @general
 502 getaddrinfo ENOTFOUND [fde3:bea9:729d::1]
```

Disclaimer: this patch is 100% slop