### PR TITLE
Fix IPv6 literals handling in proxy

### DIFF
--- a/packages/landstrip-api/lib/proxy.js
+++ b/packages/landstrip-api/lib/proxy.js
@@ -68,6 +68,10 @@ function isPublicProxyAddress(address, family = isIP(address)) {
 }
 
 async function resolveProxyEndpoint(host) {
+  // URL.hostname getter doesn't strip brackets from IPv6 address literals,
+  // we have to strip them here so lookup would work
+  host = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+
   const literalFamily = isIP(host);
   if (literalFamily === 4 || literalFamily === 6) {
     if (!isPublicProxyAddress(host, literalFamily)) {


### PR DESCRIPTION
Without the fix, URLs like http://[fde3:bea9:729d::1]:8080/ resulted in string `[fde3:bea9:729d::1]` (with brackets) getting passed to the resolver, which doesn't work.

The root cause is [URL.hostname getter](https://nodejs.org/api/url.html#urlhostname) which doesn't remote the brackets from the IPv6 literals.

Fixes #127